### PR TITLE
Fetch polygon AOI for each hazard

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,8 +9,9 @@ install-lambda-deps:
 	python -m pip install -r hyp3-floods/requirements.txt -t hyp3-floods/src/ && \
 	python -m pip install -r transfer-products/requirements.txt -t transfer-products/src/
 
+test_file ?= 'tests/'
 test:
-	pytest tests/
+	pytest $(test_file)
 
 static: flake8 cfn-lint
 

--- a/hyp3-floods/src/hyp3_floods.py
+++ b/hyp3-floods/src/hyp3_floods.py
@@ -52,9 +52,19 @@ class HyP3SubscriptionsAPI:
         return response.json()
 
 
-def get_active_hazards(auth_token: str) -> list[dict]:
+def get_aoi(pdc_auth_token: str, hazard_id: int) -> str:
+    # TODO compare polygon aoi with point?
+    # return f'POINT({hazard["longitude"]} {hazard["latitude"]})'
+
+    url = f'{PDC_URL}/hp_srv/services/hazard/{hazard_id}/alertGeography'
+    response = requests.get(url, headers={'Authorization': f'Bearer {pdc_auth_token}'})
+    response.raise_for_status()
+    return response.json()['wkt']['text']
+
+
+def get_active_hazards(pdc_auth_token: str) -> list[dict]:
     url = f'{PDC_URL}/hp_srv/services/hazards/t/json/get_active_hazards'
-    response = requests.get(url, headers={'Authorization': f'Bearer {auth_token}'})
+    response = requests.get(url, headers={'Authorization': f'Bearer {pdc_auth_token}'})
     response.raise_for_status()
     return response.json()
 
@@ -80,19 +90,31 @@ def get_existing_subscription(hyp3: HyP3SubscriptionsAPI, name: str) -> Optional
     return subscriptions[0] if subscriptions else None
 
 
-def process_active_hazards(hyp3: HyP3SubscriptionsAPI, active_hazards: list[dict], end: str, dry_run: bool) -> None:
+def process_active_hazards(
+        pdc_auth_token: str,
+        hyp3: HyP3SubscriptionsAPI,
+        active_hazards: list[dict],
+        end: str,
+        dry_run: bool) -> None:
     for count, hazard in enumerate(active_hazards, start=1):
         print(f'({count}/{len(active_hazards)}) Processing hazard {hazard["uuid"]}')
         try:
-            process_active_hazard(hyp3, hazard, end, dry_run=dry_run)
+            process_active_hazard(pdc_auth_token, hyp3, hazard, end, dry_run=dry_run)
         except (requests.HTTPError, DuplicateSubscriptionNames) as e:
             print(f'Error while processing hazard {hazard["uuid"]}: {e}')
 
 
-def process_active_hazard(hyp3: HyP3SubscriptionsAPI, hazard: dict, end: str, dry_run: bool) -> None:
+def process_active_hazard(
+        pdc_auth_token: str,
+        hyp3: HyP3SubscriptionsAPI,
+        hazard: dict,
+        end: str,
+        dry_run: bool) -> None:
     name = subscription_name_from_hazard_uuid(hazard['uuid'])
     start = get_start_datetime_str(int(hazard['start_Date']))
-    aoi = get_aoi(hazard)
+
+    print(f'Fetching AOI for hazard ID: {hazard["hazard_ID"]}')
+    aoi = get_aoi(pdc_auth_token, hazard['hazard_ID'])
 
     print(f'Fetching existing subscription with name: {name}')
     existing_subscription = get_existing_subscription(hyp3, name)
@@ -127,11 +149,6 @@ def log_updates(existing_subscription: dict, new_start: str, new_aoi: str) -> No
 
     if existing_aoi != new_aoi:
         print(f'Updating AOI for subscription {subscription_id} from {existing_aoi} to {new_aoi}')
-
-
-def get_aoi(hazard: dict) -> str:
-    # TODO get real aoi
-    return f'POINT({hazard["longitude"]} {hazard["latitude"]})'
 
 
 def str_from_datetime(date_time: datetime) -> str:
@@ -210,7 +227,7 @@ def main(dry_run: bool) -> None:
     if dry_run:
         print('(DRY RUN)')
 
-    auth_token = get_env_var('PDC_HAZARDS_AUTH_TOKEN')
+    pdc_auth_token = get_env_var('PDC_HAZARDS_AUTH_TOKEN')
     hyp3_url = get_env_var('HYP3_URL')
     earthdata_username = get_env_var('EARTHDATA_USERNAME')
     earthdata_password = get_env_var('EARTHDATA_PASSWORD')
@@ -222,7 +239,7 @@ def main(dry_run: bool) -> None:
     hyp3 = HyP3SubscriptionsAPI(hyp3_url, earthdata_username, earthdata_password)
 
     print('Fetching active hazards')
-    active_hazards = get_active_hazards(auth_token)
+    active_hazards = get_active_hazards(pdc_auth_token)
     print(f'Active hazards (before filtering): {len(active_hazards)}')
 
     current_time_in_ms = get_current_time_in_ms()
@@ -230,7 +247,7 @@ def main(dry_run: bool) -> None:
     print(f'Active hazards (after filtering): {len(active_hazards)}')
 
     end = get_end_datetime_str(current_time_in_ms)
-    process_active_hazards(hyp3, active_hazards, end, dry_run=dry_run)
+    process_active_hazards(pdc_auth_token, hyp3, active_hazards, end, dry_run=dry_run)
 
 
 if __name__ == '__main__':

--- a/hyp3-floods/src/hyp3_floods.py
+++ b/hyp3-floods/src/hyp3_floods.py
@@ -53,9 +53,6 @@ class HyP3SubscriptionsAPI:
 
 
 def get_aoi(pdc_auth_token: str, hazard_id: int) -> str:
-    # TODO compare polygon aoi with point?
-    # return f'POINT({hazard["longitude"]} {hazard["latitude"]})'
-
     url = f'{PDC_URL}/hp_srv/services/hazard/{hazard_id}/alertGeography'
     response = requests.get(url, headers={'Authorization': f'Bearer {pdc_auth_token}'})
     response.raise_for_status()

--- a/tests/test_hyp3_floods.py
+++ b/tests/test_hyp3_floods.py
@@ -73,8 +73,8 @@ def test_lambda_handler(
 
     end = '2022-05-27T16:29:04Z'
     assert mock_process_active_hazard.mock_calls == [
-        call(mock_hyp3_api, active_hazards[0], end, dry_run=False),
-        call(mock_hyp3_api, active_hazards[2], end, dry_run=False),
+        call('test-token', mock_hyp3_api, active_hazards[0], end, dry_run=False),
+        call('test-token', mock_hyp3_api, active_hazards[2], end, dry_run=False),
     ]
 
 
@@ -84,20 +84,24 @@ def test_lambda_handler_missing_env_var():
         hyp3_floods.lambda_handler(None, None)
 
 
-def test_process_active_hazard_submit():
+@patch('hyp3_floods.get_aoi')
+def test_process_active_hazard_submit(mock_get_aoi: MagicMock):
     mock_hyp3 = NonCallableMock(hyp3_floods.HyP3SubscriptionsAPI)
     mock_hyp3.get_subscriptions_by_name.return_value = {'subscriptions': []}
     mock_hyp3.submit_subscription.return_value = {'subscription': {'subscription_id': ''}}
 
+    mock_get_aoi.return_value = 'POINT(48.0 38.0)'
+
     hazard = {
         'uuid': '123',
+        'hazard_ID': 789,
         'start_Date': '1650388111000',
-        'latitude': 38.39,
-        'longitude': 47.94
     }
     end = 'test-end-datetime'
 
-    hyp3_floods.process_active_hazard(mock_hyp3, hazard, end, dry_run=False)
+    hyp3_floods.process_active_hazard('test-token', mock_hyp3, hazard, end, dry_run=False)
+
+    mock_get_aoi.assert_called_once_with('test-token', 789)
 
     name = 'PDC-hazard-123'
     new_subscription = {
@@ -108,7 +112,7 @@ def test_process_active_hazard_submit():
             'polarization': ['VV+VH'],
             'start': '2022-04-19T16:08:31Z',
             'end': end,
-            'intersectsWith': 'POINT(47.94 38.39)'
+            'intersectsWith': 'POINT(48.0 38.0)'
         },
         'job_specification': {
             'job_type': 'WATER_MAP',
@@ -130,7 +134,8 @@ def test_process_active_hazard_submit():
 
 
 @patch('builtins.print')
-def test_process_active_hazard_update(mock_print: MagicMock):
+@patch('hyp3_floods.get_aoi')
+def test_process_active_hazard_update(mock_get_aoi: MagicMock, mock_print: MagicMock):
     mock_hyp3 = NonCallableMock(hyp3_floods.HyP3SubscriptionsAPI)
     mock_hyp3.get_subscriptions_by_name.return_value = {
         'subscriptions': [
@@ -144,14 +149,17 @@ def test_process_active_hazard_update(mock_print: MagicMock):
         ]
     }
 
+    mock_get_aoi.return_value = 'POINT(2.0 1.0)'
+
     hazard = {
         'uuid': '123',
+        'hazard_ID': 789,
         'start_Date': '1655251200000',
-        'latitude': 1.0,
-        'longitude': 2.0,
     }
 
-    hyp3_floods.process_active_hazard(mock_hyp3, hazard, 'test-end-datetime', dry_run=False)
+    hyp3_floods.process_active_hazard('test-token', mock_hyp3, hazard, 'test-end-datetime', dry_run=False)
+
+    mock_get_aoi.assert_called_once_with('test-token', 789)
 
     mock_hyp3.get_subscriptions_by_name.assert_called_once_with('PDC-hazard-123')
 
@@ -174,16 +182,19 @@ def test_process_active_hazard_update(mock_print: MagicMock):
     ) in mock_print.mock_calls
 
 
-def test_process_active_hazard_duplicate_subscription_names():
+@patch('hyp3_floods.get_aoi')
+def test_process_active_hazard_duplicate_subscription_names(mock_get_aoi: MagicMock):
     mock_hyp3 = NonCallableMock(hyp3_floods.HyP3SubscriptionsAPI)
     mock_hyp3.get_subscriptions_by_name.return_value = {
         'subscriptions': [{'subscription_id': 'foo'}, {'subscription_id': 'bar'}]
     }
 
-    hazard = {'uuid': '123', 'start_Date': '1', 'latitude': '', 'longitude': ''}
+    hazard = {'uuid': '123', 'hazard_ID': 789, 'start_Date': '1'}
 
     with pytest.raises(hyp3_floods.DuplicateSubscriptionNames):
-        hyp3_floods.process_active_hazard(mock_hyp3, hazard, 'test-end-datetime', dry_run=False)
+        hyp3_floods.process_active_hazard('test-token', mock_hyp3, hazard, 'test-end-datetime', dry_run=False)
+
+    mock_get_aoi.assert_called_once_with('test-token', 789)
 
     mock_hyp3.get_subscriptions_by_name.assert_called_once_with('PDC-hazard-123')
 
@@ -233,11 +244,6 @@ def test_is_valid_hazard():
         {'category_ID': 'EVENT', 'severity_ID': 'WARNING', 'type_ID': 'FLOOD', 'start_Date': 3},
         current_time_in_ms=2
     ) is False
-
-
-def test_get_aoi():
-    hazard = {'latitude': 37.949, 'longitude': -90.4527}
-    assert hyp3_floods.get_aoi(hazard) == 'POINT(-90.4527 37.949)'
 
 
 def test_str_from_datetime():

--- a/tests/test_hyp3_floods.py
+++ b/tests/test_hyp3_floods.py
@@ -90,7 +90,7 @@ def test_process_active_hazard_submit(mock_get_aoi: MagicMock):
     mock_hyp3.get_subscriptions_by_name.return_value = {'subscriptions': []}
     mock_hyp3.submit_subscription.return_value = {'subscription': {'subscription_id': ''}}
 
-    mock_get_aoi.return_value = 'POINT(48.0 38.0)'
+    mock_get_aoi.return_value = 'POLYGON((48.0 38.0))'
 
     hazard = {
         'uuid': '123',
@@ -112,7 +112,7 @@ def test_process_active_hazard_submit(mock_get_aoi: MagicMock):
             'polarization': ['VV+VH'],
             'start': '2022-04-19T16:08:31Z',
             'end': end,
-            'intersectsWith': 'POINT(48.0 38.0)'
+            'intersectsWith': 'POLYGON((48.0 38.0))'
         },
         'job_specification': {
             'job_type': 'WATER_MAP',
@@ -143,13 +143,13 @@ def test_process_active_hazard_update(mock_get_aoi: MagicMock, mock_print: Magic
                 'subscription_id': 'test-subscription-id',
                 'search_parameters': {
                     'start': '2022-03-01T00:00:00Z',
-                    'intersectsWith': 'POINT(0.0 0.0)',
+                    'intersectsWith': 'POLYGON((0.0 0.0))',
                 }
             }
         ]
     }
 
-    mock_get_aoi.return_value = 'POINT(2.0 1.0)'
+    mock_get_aoi.return_value = 'POLYGON((2.0 1.0))'
 
     hazard = {
         'uuid': '123',
@@ -167,7 +167,7 @@ def test_process_active_hazard_update(mock_get_aoi: MagicMock, mock_print: Magic
         subscription_id='test-subscription-id',
         start='2022-06-14T23:00:00Z',
         end='test-end-datetime',
-        intersectsWith='POINT(2.0 1.0)',
+        intersectsWith='POLYGON((2.0 1.0))',
         enabled=True,
     )
 
@@ -178,7 +178,7 @@ def test_process_active_hazard_update(mock_get_aoi: MagicMock, mock_print: Magic
 
     assert call(
         'Updating AOI for subscription test-subscription-id '
-        'from POINT(0.0 0.0) to POINT(2.0 1.0)'
+        'from POLYGON((0.0 0.0)) to POLYGON((2.0 1.0))'
     ) in mock_print.mock_calls
 
 


### PR DESCRIPTION
I ran the lambda handler locally (dry run) and here is an example log message showing a subscription being updated from the old single-point AOI to the new polygon AOI:

```
Updating AOI for subscription e6f367ad-8db7-4ef4-b106-7a932827f6c9 from POINT(-87.2563 40.0449) to MULTIPOLYGON (((-87.63 39.3, -  87.63 39.6, -87.42 39.6, -87.42 39.77, -87.35 39.77, -87.35 39.6, -87.36 39.6, -87.36 39.3, -87.63 39.3)), ((-87.47 39.97, -87.47  40.4, -87.09 40.4, -87.09 40.56, -86.7 40.56, -86.7 40.33, -87.09 40.33, -87.09 39.97, -87.47 39.97)))
```

Most of the WKT strings appear to be much longer than the one from this example.

TODO:

- [x] Confirm that HyP3 subscriptions support `MULTIPOLYGON` (Vertex does not appear to handle these correctly)