### PR TITLE
Fix runaway costs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,9 @@
 # hyp3-flood-monitoring
 
 ⚠️ **Important:** As of March 14, 2023, the test and prod flood monitoring systems have been
-temporarily disabled until key stakeholders are ready to make use of the data. We have
-set the HyP3 job quota for the `hyp3_flood_monitoring` user to `0` so that no new jobs
-will be run for flood monitoring subscriptions (but the flood monitoring system will
-continue to check for active hazards and create subscriptions).
-
-To restore the user quota for both test and prod, follow these steps:
-
-1. Identify the HyP3 deployment used by the flood monitoring system. For test,
-   this is the HyP3 deployment that corresponds to the URL given by the `HYP3_URL` parameter in the
-   [deploy-test.yml](./.github/workflows/deploy-test.yml) workflow. For prod, see the same parameter in the
-   [deploy-prod.yml](./.github/workflows/deploy-prod.yml) workflow.
-2. Log in to the AWS account corresponding to that HyP3 deployment, navigate to the DynamoDB console,
-   select the HyP3 Users Table, and confirm that there is an item for the `hyp3_flood_monitoring` user
-   with `max_jobs_per_month` set to `0`.
-3. Edit the `max_jobs_per_month` field and set it to an appropriate value, depending on how much data we want
-   the flood monitoring system to produce.
-
-We have also deleted the archived data and disabled the schedule rule that triggered
-the `TransferProducts` Lambda function
-(see [transfer-products/cloudformation.yml](transfer-products/cloudformation.yml)), in order
-to prevent the deleted data from being re-archived. To re-enable automatic data archival, follow
-these steps:
-
-1. Log in to the HyP3 AWS account (where the HyP3 Flood Monitoring systems are deployed).
-2. Navigate to CloudFormation > Stacks and select the appropriate stack for either test or prod (see the
-   `STACK_NAME` parameter in [deploy-test.yml](./.github/workflows/deploy-test.yml) or
-   [deploy-prod.yml](./.github/workflows/deploy-prod.yml)).
-3. After selecting the stack, navigate to Resources and select the TransferProducts stack, then navigate to
-   Resources and select the Schedule resource. This should open an Amazon EventBridge Rule with an Event schedule,
-   and the Rule should have a Status of Disabled.
-4. Click the Enable button to re-enable the rule. Confirm that the corresponding Lambda function resumes
-   running automatically at the appropriate interval.
+temporarily disabled until key stakeholders are ready to make use of the data. See
+https://github.com/ASFHyP3/hyp3-flood-monitoring/issues/38 for more details,
+including instructions for re-enabling processing.
 
 ## Architecture overview
 

--- a/cloudformation.yml
+++ b/cloudformation.yml
@@ -87,6 +87,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       ScheduleExpression: "rate(15 minutes)"
+      State: DISABLED # https://github.com/ASFHyP3/hyp3-flood-monitoring/issues/38
       Targets:
         - Arn: !GetAtt Lambda.Arn
           Id: lambda

--- a/transfer-products/cloudformation.yml
+++ b/transfer-products/cloudformation.yml
@@ -78,6 +78,7 @@ Resources:
     Type: AWS::Events::Rule
     Properties:
       ScheduleExpression: "rate(6 hours)"  # TODO decide on appropriate rate
+      State: DISABLED # https://github.com/ASFHyP3/hyp3-flood-monitoring/issues/38
       Targets:
         - Arn: !GetAtt Lambda.Arn
           Id: lambda


### PR DESCRIPTION
See https://github.com/ASFHyP3/hyp3-flood-monitoring/issues/39

Disables both Lambda schedules, as well as moves the instructions for re-enabling processing from the README to an issue, so that we don't have to make PRs in order to update/revise those instructions.