### PR TITLE
add missing ListBucket permissions for transfer-products lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1]
+### Fixed
+- Missing `ListBucket` permissions for transfer-products lambda function
+
 ## [0.3.0]
 ### Added
 - `ProcessingState` cloudformation parameter to support enabling/disabling processing on a per-deployment basis.

--- a/transfer-products/cloudformation.yml
+++ b/transfer-products/cloudformation.yml
@@ -46,6 +46,9 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
+                Action: s3:ListBucket
+                Resource: !Sub "arn:aws:s3:::${S3TargetBucket}"
+              - Effect: Allow
                 Action: s3:PutObject
                 Resource: !Sub "arn:aws:s3:::${S3TargetBucket}/*"
               - Effect: Allow


### PR DESCRIPTION
The lambda that transfers products to `s3://hyp3-pdc-data/` is failing because it doesn't have permissions to list the contents of the bucket when deciding which products need to be transferred:
```
[ERROR] ClientError: An error occurred (AccessDenied) when calling the ListObjects operation: Access Denied Traceback (most recent call last):   File "/var/task/transfer_products.py", line 109, in lambda_handler     main(dry_run=False)   File "/var/task/transfer_products.py", line 130, in main     existing_objects = get_existing_objects(target_bucket, target_prefix)   File "/var/task/transfer_products.py", line 28, in get_existing_objects     return frozenset(obj.key for obj in S3.Bucket(target_bucket).objects.filter(Prefix=f'{target_prefix}/'))   File "/var/task/transfer_products.py", line 28, in <genexpr>     return frozenset(obj.key for obj in S3.Bucket(target_bucket).objects.filter(Prefix=f'{target_prefix}/'))   File "/var/task/boto3/resources/collection.py", line 81, in __iter__     for page in self.pages():   File "/var/task/boto3/resources/collection.py", line 171, in pages     for page in pages:   File "/var/task/botocore/paginate.py", line 269, in __iter__     response = self._make_request(current_kwargs)   File "/var/task/botocore/paginate.py", line 357, in _make_request     return self._method(**current_kwargs)   File "/var/task/botocore/client.py", line 530, in _api_call     return self._make_api_call(operation_name, kwargs)   File "/var/task/botocore/client.py", line 964, in _make_api_call     raise error_class(parsed_response, operation_name)
```

I *think* this worked before because the previous bucket was in the same account with public ListBucket permissions, so there was no need to specify the permissions on the lambda side. Now that the bucket and lambda are in different accounts we need to be explicit on both sides of the handshake.