### PR TITLE
grant s3:GetObject permissions for transfer-products lambda

### DIFF
--- a/transfer-products/cloudformation.yml
+++ b/transfer-products/cloudformation.yml
@@ -47,7 +47,7 @@ Resources:
             Statement:
               - Effect: Allow
                 Action: s3:GetObject
-                Resource: !Sub "arn:aws:s3:::*"
+                Resource: arn:aws:s3:::*
               - Effect: Allow
                 Action: s3:ListBucket
                 Resource: !Sub "arn:aws:s3:::${S3TargetBucket}"

--- a/transfer-products/cloudformation.yml
+++ b/transfer-products/cloudformation.yml
@@ -46,6 +46,9 @@ Resources:
             Version: 2012-10-17
             Statement:
               - Effect: Allow
+                Action: s3:GetObject
+                Resource: !Sub "arn:aws:s3:::*"
+              - Effect: Allow
                 Action: s3:ListBucket
                 Resource: !Sub "arn:aws:s3:::${S3TargetBucket}"
               - Effect: Allow


### PR DESCRIPTION
Now that we're transferring files using `s3.Bucket.copy()`, instead of downloading them via the public URL using `requests`, we need to grant s3 permissions to read the source data from HyP3.

I'm leaving the permissions generic so transfer-products could potentially read data from any (or all) hyp3 deployments, but I could be talked into adding a `SourceBucket` cloudformation parameter to make the read permissions specific.

We're using `s3.Bucket.copy()`, I can't remember if that function tries to copy S3 tags along with the object, so we might end up also needing `s3:GetObjectTagging` permissions.