### PR TITLE
don't copy s3 tags in transfer-products

### DIFF
--- a/transfer-products/src/transfer_products.py
+++ b/transfer-products/src/transfer_products.py
@@ -77,7 +77,7 @@ def copy_object(source_bucket, source_key, target_bucket, target_key, chunk_size
     bucket = S3.Bucket(target_bucket)
     copy_source = {'Bucket': source_bucket, 'Key': source_key}
     transfer_config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
-    extra_args = {'TaggingDirective' : 'REPLACE'}
+    extra_args = {'TaggingDirective': 'REPLACE'}
     bucket.copy(CopySource=copy_source, Key=target_key, Config=transfer_config, ExtraArgs=extra_args)
 
 

--- a/transfer-products/src/transfer_products.py
+++ b/transfer-products/src/transfer_products.py
@@ -77,7 +77,8 @@ def copy_object(source_bucket, source_key, target_bucket, target_key, chunk_size
     bucket = S3.Bucket(target_bucket)
     copy_source = {'Bucket': source_bucket, 'Key': source_key}
     transfer_config = TransferConfig(multipart_threshold=chunk_size, multipart_chunksize=chunk_size)
-    bucket.copy(CopySource=copy_source, Key=target_key, Config=transfer_config)
+    extra_args = {'TaggingDirective' : 'REPLACE'}
+    bucket.copy(CopySource=copy_source, Key=target_key, Config=transfer_config, ExtraArgs=extra_args)
 
 
 def get_env_var(name: str) -> str:


### PR DESCRIPTION
https://github.com/ASFHyP3/hyp3-flood-monitoring/pull/50 half worked. The function was able to successfully copy files larger than our chunk size of 100 MB, but failed with `AccessDenied` when trying to copy files smaller than 100 MB:

![Screenshot from 2023-06-21 16-57-57](https://github.com/ASFHyP3/hyp3-flood-monitoring/assets/17994518/7a2f4daf-59f0-4c81-a26b-066839c7143d)

As described at https://stackoverflow.com/questions/60807368/aws-boto3-s3-copy-not-copying-tags , `s3.Bucket.copy()` copies the large files in chunks, and the smaller files all at once. It doesn't attempt to copy S3 tags for multi-part transfers, only for single-part transfers. The small, single-part transfer files failed because we haven't given the lambda `s3:GetObjectTagging` permissions to read the source tags.

I don't think we care about preserving tags at all, so this PR sets the `TaggingDirective` option of [copy_object](https://boto3.amazonaws.com/v1/documentation/api/latest/reference/services/s3/client/copy_object.html) to not try copying them at all, so we don't need to worry about extra permissions.