### PR TITLE
Additional transfer-products throughput

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.1]
 ### Changed
-- `transfer-products` lambda now runs every 30 minutes instead of every six hours.
+- `transfer-products` now runs every 30 minutes instead of every six hours.
+- `transfer-products` no longer transfers the `dem.tif` product.
 
 ## [0.4.0]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1]
+### Changed
+- `transfer-products` lambda now runs every 30 minutes instead of every six hours.
+
 ## [0.4.0]
 ### Changed
 - S3 objects are now copied directly to the target bucket, rather than being downloaded and uploaded.

--- a/transfer-products/cloudformation.yml
+++ b/transfer-products/cloudformation.yml
@@ -76,8 +76,6 @@ Resources:
       Role: !GetAtt Role.Arn
       Runtime: python3.9
       Timeout: 900
-      EphemeralStorage:
-        Size: 1024 # MB
 
   EventInvokeConfig:
     Type: AWS::Lambda::EventInvokeConfig
@@ -89,7 +87,7 @@ Resources:
   Schedule:
     Type: AWS::Events::Rule
     Properties:
-      ScheduleExpression: "rate(6 hours)"  # TODO decide on appropriate rate
+      ScheduleExpression: "rate(30 minutes)"
       State: !Ref ProcessingState
       Targets:
         - Arn: !GetAtt Lambda.Arn

--- a/transfer-products/src/transfer_products.py
+++ b/transfer-products/src/transfer_products.py
@@ -10,7 +10,7 @@ from boto3.s3.transfer import TransferConfig
 S3 = boto3.resource('s3')
 
 # TODO decide on appropriate extensions
-EXTENSIONS = ['_VV.tif', '_VH.tif', '_rgb.tif', '_dem.tif', '_WM.tif', '.README.md.txt']
+EXTENSIONS = ['_VV.tif', '_VH.tif', '_rgb.tif', '_WM.tif', '.README.md.txt']
 
 
 @dataclass(frozen=True)


### PR DESCRIPTION
The throughput change in v0.4.0 increased the transfer rate from ~200 files per execution to ~350 files per execution. Increasing the frequency and no longer transferring the dem geotiff should let us handle up to a few thousand jobs per day.

350 files / execution * 2 executions/hour * 24 hours/day * 1/5 jobs/file = ~3,360 jobs/day